### PR TITLE
Update Node.js version and remove link

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ pnpm run build
 
 ## Requirements
 
-- Node.js (v18+ recommended)
+- Node.js (v24+ recommended)
 - pnpm
 
 ## License
@@ -123,4 +123,3 @@ Pull requests and suggestions are welcome!
 # SEE ALSO
 
 - [GreasyFork](https://greasyfork.org/en/users/9112-bricemciver)
-- [OpenUserJS](https://openuserjs.org/users/bricem)


### PR DESCRIPTION
Updated Node.js version requirement from v18+ to v24+ and removed OpenUserJS link.