### PR TITLE
feat: add equip-bid auto-login userscript

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "lts"
+pnpm = "10.15.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "uuid": "^13.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.15.30",
+    "@types/node": "^22.19.19",
     "@types/tampermonkey": "^5.0.4",
     "bundle-require": "^5.1.0",
     "chokidar": "^5.0.0",
@@ -28,7 +28,7 @@
     "tsx": "^4.21.0",
     "typescript": "^5.8.3",
     "vite": "^8.0.5",
-    "vite-plugin-monkey": "^7.1.4",
+    "vite-plugin-monkey": "^8.0.6",
     "zx": "^8.8.5"
   },
   "simple-git-hooks": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         version: 13.0.0
     devDependencies:
       '@types/node':
-        specifier: ^22.15.30
-        version: 22.19.15
+        specifier: ^22.19.19
+        version: 22.19.19
       '@types/tampermonkey':
         specifier: ^5.0.4
         version: 5.0.5
@@ -44,10 +44,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.5
-        version: 8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.19)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-monkey:
-        specifier: ^7.1.4
-        version: 7.1.9(postcss@8.5.8)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: ^8.0.6
+        version: 8.0.6(postcss@8.5.8)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.19)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
       zx:
         specifier: ^8.8.5
         version: 8.8.5
@@ -327,11 +327,139 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.12':
     resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
 
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  '@types/node@22.19.15':
-    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
   '@types/tampermonkey@5.0.5':
     resolution: {integrity: sha512-ZWitwJH4T/jcQiynhc3I5DNiwlsDzVTKPXg6A8ltTw3SDuf0b00bNRSV0Z/yldnhhBi9e8g8vY/X3LVSQcaCKQ==}
@@ -421,29 +549,28 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  dom-serializer@2.0.0:
-    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
 
-  domelementtype@2.3.0:
-    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
-  domhandler@5.0.3:
-    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
-    engines: {node: '>= 4'}
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
 
-  domutils@3.2.2:
-    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
-  entities@4.5.0:
-    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
-    engines: {node: '>=0.12'}
-
-  entities@7.0.1:
-    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
-    engines: {node: '>=0.12'}
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -478,8 +605,9 @@ packages:
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
-  htmlparser2@10.1.0:
-    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -492,6 +620,10 @@ packages:
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
+
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
 
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -624,9 +756,9 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  open@10.2.0:
-    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
-    engines: {node: '>=18'}
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -648,6 +780,10 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
 
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
@@ -671,6 +807,11 @@ packages:
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   run-applescript@7.1.0:
@@ -756,10 +897,10 @@ packages:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
 
-  vite-plugin-monkey@7.1.9:
-    resolution: {integrity: sha512-kYtcRH8DsbrwfugrviYRuk50weY5yyVKcuGRkjUSc7mK0uPFtOHK8sUSEecpiS9725IF/4uyum8bYHs7dswDBg==}
+  vite-plugin-monkey@8.0.6:
+    resolution: {integrity: sha512-DpNKGLpATKMiFh0m0UaT85oEZYUJ4gtKeaTmL/zyR2jmCmuuybJGC1iI5+wJzLASZpdkTF055UDxVfHtF1RlNQ==}
     peerDependencies:
-      vite: ^6.0.0 || ^7.0.0
+      vite: ^8.0.0
     peerDependenciesMeta:
       vite:
         optional: true
@@ -816,9 +957,9 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  wsl-utils@0.1.0:
-    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
-    engines: {node: '>=18'}
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
 
   xxhashjs@0.2.2:
     resolution: {integrity: sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==}
@@ -994,12 +1135,89 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.12': {}
 
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@types/node@22.19.15':
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
 
@@ -1077,29 +1295,27 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  dom-serializer@2.0.0:
+  dom-serializer@3.1.1:
     dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      entities: 4.5.0
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
 
-  domelementtype@2.3.0: {}
+  domelementtype@3.0.0: {}
 
-  domhandler@5.0.3:
+  domhandler@6.0.1:
     dependencies:
-      domelementtype: 2.3.0
+      domelementtype: 3.0.0
 
-  domutils@3.2.2:
+  domutils@4.0.2:
     dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   emoji-regex@10.6.0: {}
 
-  entities@4.5.0: {}
-
-  entities@7.0.1: {}
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 
@@ -1147,12 +1363,12 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  htmlparser2@10.1.0:
+  htmlparser2@12.0.0:
     dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      entities: 7.0.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
 
   import-meta-resolve@4.2.0: {}
 
@@ -1161,6 +1377,8 @@ snapshots:
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.5.0
+
+  is-in-ssh@1.0.0: {}
 
   is-inside-container@1.0.0:
     dependencies:
@@ -1273,12 +1491,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  open@10.2.0:
+  open@11.0.0:
     dependencies:
       default-browser: 5.5.0
       define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
       is-inside-container: 1.0.0
-      wsl-utils: 0.1.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
 
   path-key@3.1.1: {}
 
@@ -1299,6 +1519,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  powershell-utils@0.1.0: {}
 
   prettier@3.8.1: {}
 
@@ -1336,6 +1558,37 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
 
   run-applescript@7.1.0: {}
 
@@ -1405,25 +1658,25 @@ snapshots:
 
   uuid@13.0.0: {}
 
-  vite-plugin-monkey@7.1.9(postcss@8.5.8)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-monkey@8.0.6(postcss@8.5.8)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.19)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      acorn: 8.16.0
       acorn-walk: 8.3.5
       cross-spawn: 7.0.6
-      htmlparser2: 10.1.0
+      htmlparser2: 12.0.0
       import-meta-resolve: 4.2.0
       magic-string: 0.30.21
       mrmime: 2.0.1
-      open: 10.2.0
+      open: 11.0.0
       picocolors: 1.1.1
       postcss-url: 10.1.3(postcss@8.5.8)
+      rollup: 4.60.4
       systemjs: 6.15.1
     optionalDependencies:
-      vite: 8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.19)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - postcss
 
-  vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.19)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -1431,7 +1684,7 @@ snapshots:
       rolldown: 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 22.19.19
       esbuild: 0.27.4
       fsevents: 2.3.3
       tsx: 4.21.0
@@ -1450,9 +1703,10 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  wsl-utils@0.1.0:
+  wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.1
+      powershell-utils: 0.1.0
 
   xxhashjs@0.2.2:
     dependencies:

--- a/src/plugins/equip-bid-auto-login/README.md
+++ b/src/plugins/equip-bid-auto-login/README.md
@@ -1,0 +1,37 @@
+# Equip-Bid Auto Login
+
+A userscript that keeps you logged into equip-bid.com by re-submitting your saved credentials whenever your session expires.
+
+## What it does
+
+equip-bid.com keeps you signed in via an `oas-equip-bid` session cookie. On a successful login the server issues it as a persistent cookie that lasts one week (`Max-Age=604800`); once that week lapses — or you log out — the cookie is gone and you have to sign in again. The cookie is `HttpOnly`, so it is read with Tampermonkey's `GM_cookie` API.
+
+On every equip-bid page this script checks for a valid (present and unexpired) session cookie. If it's missing or expired and you have saved credentials, it silently POSTs them to the same endpoint the login form uses, then reloads the page you were heading to — now signed in.
+
+## Features
+
+- **Automatic re-login**: Detects a missing/expired session and logs you back in without interrupting your browsing
+- **Returns you to your page**: After logging in, you land on the page you originally requested (via the login form's `return` parameter)
+- **Simple credentials UI**: A Tampermonkey menu command, **"Set equip-bid credentials"**, opens a small dialog to enter, update, or clear your email and password
+- **Loop-safe**: Only one login attempt per navigation, so a bad password can't cause a reload loop
+- **Easy Installation**: Compatible with Tampermonkey and other userscript managers that support `GM_cookie`
+
+## Installation
+
+1. Install a userscript manager like [Tampermonkey](https://www.tampermonkey.net/)
+2. Download the userscript from <https://github.com/bricemciver/GreasemonkeyScripts/releases/latest/download/equip-bid-auto-login.user.js>
+
+## How to Use
+
+1. **Save your credentials**: Open the Tampermonkey menu on any equip-bid.com page and click **"Set equip-bid credentials"**, then enter your email and password and click **Save**.
+2. **Browse normally**: Whenever your one-week session has expired, the script logs you in again automatically and reloads the page you wanted.
+3. **Update or remove credentials**: Reopen the same menu command to change them, or click **Clear saved** to remove them.
+
+## Security note
+
+Your email and password are stored **in plain text** in Tampermonkey's local storage on your machine. Anyone with access to your browser profile / Tampermonkey dashboard can read them. Use this only on a device you trust.
+
+## How it works
+
+- **Login detection** — `GM_cookie.list` reads the `HttpOnly` `oas-equip-bid` cookie; you're considered logged in only if it exists and has a future expiry. (Logout sets it to `deleted` with an expiry in the past, and a week-old login simply drops it.)
+- **Login** — a background `GM_xmlhttpRequest` POST to `https://www.equip-bid.com/user/account/login` with `emailAddress`, `password`, `return`, and `submit`, exactly as the real form submits. The form has no CSRF token, so no token scraping is needed. Success is confirmed by re-reading the cookie.

--- a/src/plugins/equip-bid-auto-login/manifest.ts
+++ b/src/plugins/equip-bid-auto-login/manifest.ts
@@ -1,0 +1,30 @@
+import type { MonkeyUserScript } from 'vite-plugin-monkey'
+export function manifest(): MonkeyUserScript {
+  return {
+    name: 'Equip-Bid Auto Login',
+    namespace: 'https://github.com/bricemciver/GreasemonekeyScripts',
+    description:
+      'Keep yourself logged into equip-bid.com: when the session cookie is missing or expired, silently re-submit your saved credentials and return you to the page you were headed to.',
+    license: 'MIT',
+    version: '0.1',
+    match: 'https://www.equip-bid.com/*',
+    icon: 'https://www.google.com/s2/favicons?sz=64&domain=equip-bid.com',
+    grant: [
+      'GM_xmlhttpRequest',
+      'GM.xmlHttpRequest',
+      'GM_cookie',
+      'GM.cookie',
+      'GM_getValue',
+      'GM.getValue',
+      'GM_setValue',
+      'GM.setValue',
+      'GM_deleteValue',
+      'GM.deleteValue',
+      'GM_registerMenuCommand',
+      'GM.registerMenuCommand',
+    ],
+    connect: 'equip-bid.com',
+    'run-at': 'document-start',
+    supportURL: 'https://github.com/bricemciver/GreasemonkeyScripts/issues',
+  }
+}

--- a/src/plugins/equip-bid-auto-login/userscript.ts
+++ b/src/plugins/equip-bid-auto-login/userscript.ts
@@ -1,0 +1,261 @@
+// Equip-Bid Auto Login
+//
+// equip-bid.com sets an `oas-equip-bid` session cookie. On a successful login the
+// server re-issues it as a *persistent* cookie with `Max-Age=604800` (one week);
+// on logout (or once the week lapses) the cookie is deleted/absent. The cookie is
+// HttpOnly, so it can only be read via GM_cookie, not document.cookie.
+//
+// On every equip-bid page we read that cookie. If it is missing or already expired,
+// and the user has saved credentials, we POST those credentials in the background to
+// the same endpoint the login form uses, then reload the page the user was heading to
+// (now authenticated). Credentials are entered/edited through a Tampermonkey menu
+// command that opens a small in-page dialog.
+
+const SESSION_COOKIE = 'oas-equip-bid'
+const LOGIN_ENDPOINT = 'https://www.equip-bid.com/user/account/login'
+
+// Tampermonkey storage keys.
+const EMAIL_KEY = 'emailAddress'
+const PASSWORD_KEY = 'password'
+
+// Set on the navigation right before a login attempt, so a failed attempt cannot
+// spin into a reload loop. Lives in sessionStorage so it is scoped to this tab and
+// cleared automatically when the tab closes.
+const ATTEMPT_FLAG = 'equipBidAutoLoginAttempted'
+
+type Credentials = { email: string; password: string }
+
+const getCredentials = (): Credentials => ({
+  email: GM_getValue<string>(EMAIL_KEY, ''),
+  password: GM_getValue<string>(PASSWORD_KEY, ''),
+})
+
+const saveCredentials = ({ email, password }: Credentials): void => {
+  GM_setValue(EMAIL_KEY, email)
+  GM_setValue(PASSWORD_KEY, password)
+}
+
+const clearCredentials = (): void => {
+  GM_deleteValue(EMAIL_KEY)
+  GM_deleteValue(PASSWORD_KEY)
+}
+
+// Resolve the current login session cookie (or undefined if there isn't one).
+const getSessionCookie = (): Promise<Tampermonkey.Cookie | undefined> =>
+  new Promise((resolve) => {
+    GM_cookie.list({ name: SESSION_COOKIE }, (cookies, error) => {
+      if (error || !cookies || cookies.length === 0) {
+        resolve(undefined)
+      } else {
+        resolve(cookies[0])
+      }
+    })
+  })
+
+// We are logged in only when the cookie exists AND is persistent with a future
+// expiry. A deleted cookie is absent; an anonymous/session cookie has no future
+// expirationDate. expirationDate is in seconds since the Unix epoch.
+const isLoggedIn = (cookie: Tampermonkey.Cookie | undefined): boolean => {
+  if (!cookie || cookie.session || !cookie.expirationDate) {
+    return false
+  }
+  return cookie.expirationDate * 1000 > Date.now()
+}
+
+// POST the saved credentials to the login endpoint exactly as the real form does.
+// `return` tells the server where to send us after login; the form also includes an
+// empty `submit` field, mirrored here. Success is confirmed by re-reading the cookie
+// rather than trusting the response body.
+const attemptLogin = (credentials: Credentials, returnPath: string): Promise<boolean> => {
+  const body = new URLSearchParams({
+    emailAddress: credentials.email,
+    password: credentials.password,
+    return: returnPath,
+    submit: '',
+  }).toString()
+
+  return new Promise((resolve) => {
+    GM_xmlhttpRequest({
+      method: 'POST',
+      url: LOGIN_ENDPOINT,
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      data: body,
+      onload: () => {
+        // The browser commits the response's Set-Cookie before onload fires, so
+        // re-reading the cookie tells us whether a real session was established
+        // (more reliable than parsing the response body).
+        getSessionCookie().then((cookie) => resolve(isLoggedIn(cookie)))
+      },
+      onerror: () => resolve(false),
+      ontimeout: () => resolve(false),
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Credentials dialog
+// ---------------------------------------------------------------------------
+
+const DIALOG_ID = 'equip-bid-auto-login-dialog'
+
+const injectStyles = (): void => {
+  if (document.getElementById(`${DIALOG_ID}-styles`)) {
+    return
+  }
+  const style = document.createElement('style')
+  style.id = `${DIALOG_ID}-styles`
+  style.textContent = `
+    #${DIALOG_ID} {
+      border: none;
+      border-radius: 8px;
+      padding: 0;
+      width: 340px;
+      max-width: 90vw;
+      box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+      color: #333;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    }
+    #${DIALOG_ID}::backdrop {
+      background: rgba(0, 0, 0, 0.5);
+    }
+    #${DIALOG_ID} form { margin: 0; padding: 20px; }
+    #${DIALOG_ID} h2 { margin: 0 0 4px; font-size: 1.15rem; }
+    #${DIALOG_ID} p.hint { margin: 0 0 16px; font-size: 0.8rem; color: #777; }
+    #${DIALOG_ID} label { display: block; font-size: 0.85rem; font-weight: 600; margin: 12px 0 4px; }
+    #${DIALOG_ID} input[type="email"],
+    #${DIALOG_ID} input[type="password"] {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 8px 10px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 0.95rem;
+    }
+    #${DIALOG_ID} .buttons {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-top: 20px;
+    }
+    #${DIALOG_ID} button {
+      border: none;
+      border-radius: 4px;
+      padding: 8px 14px;
+      font-size: 0.9rem;
+      cursor: pointer;
+    }
+    #${DIALOG_ID} .right-buttons { display: flex; gap: 8px; }
+    #${DIALOG_ID} button.save { background: #2bb24c; color: #fff; }
+    #${DIALOG_ID} button.cancel { background: #e0e0e0; color: #333; }
+    #${DIALOG_ID} button.clear { background: transparent; color: #c0392b; padding-left: 0; }
+  `
+  document.head?.appendChild(style)
+}
+
+const openCredentialsDialog = (): void => {
+  injectStyles()
+
+  // Reuse an existing dialog if it is already in the DOM.
+  document.getElementById(DIALOG_ID)?.remove()
+
+  const { email, password } = getCredentials()
+
+  const dialog = document.createElement('dialog')
+  dialog.id = DIALOG_ID
+  dialog.innerHTML = `
+    <form method="dialog">
+      <h2>Equip-Bid Auto Login</h2>
+      <p class="hint">Stored locally in Tampermonkey and re-submitted automatically when your session expires.</p>
+      <label for="${DIALOG_ID}-email">Email address</label>
+      <input id="${DIALOG_ID}-email" type="email" autocomplete="off" />
+      <label for="${DIALOG_ID}-password">Password</label>
+      <input id="${DIALOG_ID}-password" type="password" autocomplete="off" />
+      <div class="buttons">
+        <button type="button" class="clear">Clear saved</button>
+        <div class="right-buttons">
+          <button type="button" class="cancel">Cancel</button>
+          <button type="submit" class="save">Save</button>
+        </div>
+      </div>
+    </form>
+  `
+
+  const emailInput = dialog.querySelector<HTMLInputElement>(`#${DIALOG_ID}-email`)
+  const passwordInput = dialog.querySelector<HTMLInputElement>(`#${DIALOG_ID}-password`)
+  if (emailInput) emailInput.value = email
+  if (passwordInput) passwordInput.value = password
+
+  // One cleanup path for every way the dialog can close (Esc, Cancel, or Save).
+  dialog.addEventListener('close', () => dialog.remove())
+
+  dialog.querySelector<HTMLButtonElement>('button.cancel')?.addEventListener('click', () => dialog.close())
+
+  dialog.querySelector<HTMLButtonElement>('button.clear')?.addEventListener('click', () => {
+    clearCredentials()
+    if (emailInput) emailInput.value = ''
+    if (passwordInput) passwordInput.value = ''
+  })
+
+  // Saving on the form's submit means both the Save button and the Enter key work;
+  // `method="dialog"` then closes the dialog (triggering the cleanup above).
+  dialog.querySelector<HTMLFormElement>('form')?.addEventListener('submit', () => {
+    saveCredentials({
+      email: emailInput?.value.trim() ?? '',
+      password: passwordInput?.value ?? '',
+    })
+    // Allow a fresh auto-login attempt now that credentials may have changed.
+    sessionStorage.removeItem(ATTEMPT_FLAG)
+    // If we are currently logged out, kick off a login right away.
+    void ensureLoggedIn()
+  })
+
+  document.body.appendChild(dialog)
+  dialog.showModal()
+}
+
+// GM_registerMenuCommand needs no DOM; the dialog itself waits for <body>.
+GM_registerMenuCommand('Set equip-bid credentials', () => {
+  if (document.body) {
+    openCredentialsDialog()
+  } else {
+    window.addEventListener('DOMContentLoaded', openCredentialsDialog, { once: true })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Auto-login flow
+// ---------------------------------------------------------------------------
+
+const ensureLoggedIn = async (): Promise<void> => {
+  const cookie = await getSessionCookie()
+  if (isLoggedIn(cookie)) {
+    return
+  }
+
+  const credentials = getCredentials()
+  if (!credentials.email || !credentials.password) {
+    console.info(
+      '[equip-bid auto-login] No saved credentials. Use the Tampermonkey menu → "Set equip-bid credentials".',
+    )
+    return
+  }
+
+  // Don't retry within the same navigation if we already tried (avoids reload loops).
+  if (sessionStorage.getItem(ATTEMPT_FLAG)) {
+    console.warn('[equip-bid auto-login] Login already attempted for this navigation; not retrying.')
+    return
+  }
+  sessionStorage.setItem(ATTEMPT_FLAG, '1')
+
+  const returnPath = location.pathname + location.search
+  const success = await attemptLogin(credentials, returnPath)
+
+  if (success) {
+    // Cookie is set; reload so the page renders in its authenticated state.
+    location.reload()
+  } else {
+    console.error('[equip-bid auto-login] Login failed. Check the saved credentials via the Tampermonkey menu.')
+  }
+}
+
+void ensureLoggedIn()


### PR DESCRIPTION
## Summary

Adds a new userscript, **`equip-bid-auto-login`**, that keeps the user signed into equip-bid.com without manual re-logins.

- equip-bid.com keeps you signed in via an `oas-equip-bid` session cookie that the server issues as a persistent, one-week cookie (`Max-Age=604800`) on successful login. The cookie is `HttpOnly`, so it is read with `GM_cookie` (not `document.cookie`).
- On every equip-bid page (`run-at document-start`) the script checks for a valid (present + unexpired) session cookie. If it is missing/expired and credentials are saved, it POSTs them in the background to the same endpoint the login form uses (`/user/account/login`), confirms success by re-reading the cookie, then reloads the page the user was heading to.
- Credentials are set/edited/cleared through a Tampermonkey menu command (**"Set equip-bid credentials"**) that opens a small in-page `<dialog>`. The form saves on Save click or Enter.

## Notes

- Credentials are stored in **plain text** in Tampermonkey storage (documented in the README). This was a deliberate choice for this single-site convenience script.
- A loop guard (one attempt per navigation, via `sessionStorage`) prevents a bad password from causing a reload loop.
- Login detection treats the session cookie as logged-in only when it is present with a future expiry, matching the observed login/logout `Set-Cookie` behavior.

## Tooling commit

Also bumps `vite-plugin-monkey` to ^8.0.6 and `@types/node` to ^22.19.19, adds `mise.toml` pinning Node LTS + pnpm 10.15.1, and updates `pnpm-lock.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)