### PR TITLE
feat: list ThisIsWhyImBroke Menu Fix in README and release v1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Parent project to hold all my Greasemonkey scripts
   - [Lichess](#lichess)
   - [Microcenter](#microcenter)
   - [Pastebin Tools](#pastebin-tools)
+  - [ThisIsWhyImBroke](#thisiswhyimbroke)
   - [Word Games](#word-games)
 - [DEVELOPMENT](#development)
 - [SEE ALSO](#see-also)
@@ -76,6 +77,10 @@ aren't ready for release and which may not even compile.
 ## Pastebin Tools
 
 - [FMHY Base64 Auto Decoder](https://greasyfork.org/en/scripts/485772-fmhy-base64-auto-decoder 'Homepage') - Decode base64-encoded links in some pastebins and make URLs clickable
+
+## ThisIsWhyImBroke
+
+- [ThisIsWhyImBroke Menu Fix](https://github.com/bricemciver/GreasemonkeyScripts/releases/latest/download/thisiswhyimbroke-menu-fix.user.js 'Download') - Makes the long "Gifts by Recipient / Occasion / Category" navigation dropdowns scrollable
 
 ## Word Games
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greasemonkeyscripts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "My collection of GreaseMonkey scripts",
   "license": "ISC",


### PR DESCRIPTION
## Summary

- Adds **ThisIsWhyImBroke Menu Fix** (introduced in #19) to the README `SCRIPTS` list under a new `ThisIsWhyImBroke` section + TOC entry.
- Bumps `package.json` to **1.0.4** to trigger the release workflow, which builds and attaches `thisiswhyimbroke-menu-fix.user.js` (the latest GitHub release is still v1.0.2, so this script was never released).

## Notes

- The README link temporarily points at the GitHub release download URL. Once the script is imported into GreasyFork, the link will be swapped to the GreasyFork homepage to match the other entries.
- `pnpm build` verified locally — the script compiles and the header reports `@version 1.0.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)