### PR TITLE
fix(amazon-goodreads-meta): restore Goodreads ratings on listing pages

### DIFF
--- a/src/plugins/amazon-goodreads-meta/manifest.ts
+++ b/src/plugins/amazon-goodreads-meta/manifest.ts
@@ -36,6 +36,7 @@ export function manifest(): MonkeyUserScript {
       'https://*.amazon.com.au/*',
     ],
     grant: ['GM_xmlhttpRequest', 'GM.xmlHttpRequest'],
+    connect: 'goodreads.com',
     icon: 'https://www.google.com/s2/favicons?sz=64&domain=amazon.com',
   }
 }

--- a/src/plugins/amazon-goodreads-meta/userscript.ts
+++ b/src/plugins/amazon-goodreads-meta/userscript.ts
@@ -2,6 +2,10 @@ const asinRegex = /^[A-Z0-9]{10}$/
 const goodreadsRegex =
   /"aggregateRating":({"@type":"AggregateRating","ratingValue":.*?,"ratingCount":.*?,"reviewCount":.*?})/
 
+// Marks an element as already enriched so repeated runs (e.g. from the
+// MutationObserver) don't insert duplicate badges for the same book.
+const PROCESSED_ATTR = 'data-goodreads-processed'
+
 interface GoodreadsData {
   rating: string
   ratingCount: string
@@ -9,28 +13,27 @@ interface GoodreadsData {
   bookUrl: string
 }
 
-// Extract ASIN from Amazon URL or page
-const extractASINs = () => {
-  const asins: string[] = []
-  // Check if a multi-book page
-  const books = document.querySelectorAll<HTMLElement>('bds-unified-book-faceout')
-  for (const item of Array.from(books)) {
+// Extract unique ASINs from the page. Handles both multi-book listing pages
+// (e.g. /firstreads) and single product pages.
+const extractASINs = (): string[] => {
+  const asins = new Set<string>()
+
+  // Multi-book listing: each book is a <bds-unified-book-faceout> custom element
+  document.querySelectorAll<HTMLElement>('bds-unified-book-faceout').forEach((item) => {
     const asin = item.dataset.csaCItemId
     if (asin && asinRegex.test(asin)) {
-      asins.push(asin)
+      asins.add(asin)
     }
-  }
+  })
 
-  // Try to extract from page meta data
+  // Single product page metadata
   const asinMeta = document.querySelector<HTMLDivElement>('div[data-asin]')
-  if (asinMeta) {
-    const asin = asinMeta.dataset.asin
-    if (asin && asinRegex.test(asin)) {
-      asins.push(asin)
-    }
+  const single = asinMeta?.dataset.asin
+  if (single && asinRegex.test(single)) {
+    asins.add(single)
   }
 
-  return asins
+  return Array.from(asins)
 }
 
 const fetchGoodreadsDataForASIN = (asin: string) => {
@@ -40,9 +43,8 @@ const fetchGoodreadsDataForASIN = (asin: string) => {
   })
 }
 
-// Insert Goodreads data into the Amazon page
-const insertGoodreadsData = (asin: string, goodreadsData: GoodreadsData) => {
-  // Create a styled container for Goodreads data
+// Build the styled Goodreads badge element.
+const buildBadge = (goodreadsData: GoodreadsData): HTMLDivElement => {
   const container = document.createElement('div')
   container.style.padding = '6px'
   container.style.margin = '5px 0'
@@ -50,10 +52,9 @@ const insertGoodreadsData = (asin: string, goodreadsData: GoodreadsData) => {
   container.style.border = '1px solid #ddd'
   container.style.borderRadius = '3px'
 
-  // Create content
   let content = `<div style="display: flex; flex-direction: column; gap: 4px; margin-bottom: 2px;">
           <span><img src="https://www.goodreads.com/favicon.ico" style="width: 16px; height: 16px; margin-right: 3px;" alt="Goodreads" />
-          <a href="${goodreadsData.bookUrl}" target="_blank" style="font-weight: bold;">Goodreads</a></span>`
+          <a href="${goodreadsData.bookUrl}" target="_blank" rel="noopener" style="font-weight: bold;">Goodreads</a></span>`
 
   if (goodreadsData.rating) {
     content += `<span style="color: #000">${goodreadsData.rating} stars</span>`
@@ -70,34 +71,46 @@ const insertGoodreadsData = (asin: string, goodreadsData: GoodreadsData) => {
   content += '</div>'
 
   container.innerHTML = content
+  return container
+}
 
-  // Find insertion point on Amazon page
-  // Check if the page is a multi-book page
-  const currentBooks = document.querySelectorAll<HTMLElement>('bds-unified-book-faceout')
-  for (const book of Array.from(currentBooks)) {
-    // Book info is in the shadow root, so we need to access it
-    const bookInfoDiv = book.shadowRoot?.querySelector<HTMLDivElement>('div[data-csa-c-item-id]')
-    if (bookInfoDiv) {
-      const bookAsin = bookInfoDiv.dataset.csaCItemId
-      if (bookAsin && bookAsin === asin) {
-        // insert as a multi-book
-        const ratings = book.shadowRoot?.querySelector('div.star-rating')
-        if (ratings) {
-          ratings.parentNode?.insertBefore(container, ratings.nextSibling)
-          break
-        }
-      }
+// Insert the Goodreads badge for a given ASIN.
+const insertGoodreadsData = (asin: string, goodreadsData: GoodreadsData) => {
+  // Multi-book listing: each book is a <bds-unified-book-faceout> custom element
+  // that renders its contents (asynchronously) into a shadow root. Attach the
+  // badge to the light-DOM host instead of reaching into the shadow DOM, so we
+  // don't depend on the shadow structure or its render timing.
+  const faceouts = document.querySelectorAll<HTMLElement>('bds-unified-book-faceout')
+  for (const faceout of Array.from(faceouts)) {
+    if (faceout.dataset.csaCItemId !== asin) {
+      continue
     }
+    if (faceout.parentElement?.querySelector(`:scope > [${PROCESSED_ATTR}="${asin}"]`)) {
+      return
+    }
+    const badge = buildBadge(goodreadsData)
+    badge.setAttribute(PROCESSED_ATTR, asin)
+    faceout.insertAdjacentElement('afterend', badge)
+    return
   }
-  // insert as a single book
+
+  // Single product page: insert after the review summary block.
   const reviewElement = document.getElementById('reviewFeatureGroup')
-  if (reviewElement) {
-    reviewElement.parentNode?.insertBefore(container, reviewElement.nextSibling)
+  if (reviewElement && !document.querySelector(`[${PROCESSED_ATTR}="${asin}"]`)) {
+    const badge = buildBadge(goodreadsData)
+    badge.setAttribute(PROCESSED_ATTR, asin)
+    reviewElement.parentNode?.insertBefore(badge, reviewElement.nextSibling)
   }
 }
 
+const processedAsins = new Set<string>()
+
 const processAsins = async (asins: string[]) => {
   for (const asin of asins) {
+    if (processedAsins.has(asin)) {
+      continue
+    }
+    processedAsins.add(asin)
     try {
       const goodreadsData = await fetchGoodreadsDataForASIN(asin)
       const url = goodreadsData.finalUrl
@@ -113,23 +126,27 @@ const processAsins = async (asins: string[]) => {
         insertGoodreadsData(asin, aggregateGoodreadsData)
       }
     } catch (error) {
+      // Allow a later run to retry this ASIN if the request failed.
+      processedAsins.delete(asin)
       console.error('Error fetching Goodreads data:', error)
     }
   }
 }
 
-// Main function to initialize the script
-const init = async () => {
-  const asins = extractASINs()
-  if (!asins || asins.length === 0) {
-    return
+// Main entry point. Runs once now and again whenever new books render in, since
+// the book faceouts on listing pages can be added/hydrated after page load.
+const init = () => {
+  const run = () => {
+    const asins = extractASINs()
+    if (asins.length > 0) {
+      processAsins(asins).catch((error) => console.error('Error in Goodreads script:', error))
+    }
   }
 
-  try {
-    await processAsins(asins)
-  } catch (error) {
-    console.error('Error in Goodreads script:', error)
-  }
+  run()
+
+  const observer = new MutationObserver(() => run())
+  observer.observe(document.body, { childList: true, subtree: true })
 }
 
 init()

--- a/src/plugins/amazon-goodreads-meta/userscript.ts
+++ b/src/plugins/amazon-goodreads-meta/userscript.ts
@@ -119,7 +119,12 @@ const insertGoodreadsData = (asin: string, goodreadsData: GoodreadsData) => {
   }
 }
 
+// ASINs we've handled (in flight, succeeded, or given up on) so the observer
+// doesn't refetch them, and a count of transport failures per ASIN so a
+// persistently-failing request isn't retried forever on every DOM mutation.
 const processedAsins = new Set<string>()
+const failedAttempts = new Map<string, number>()
+const MAX_ATTEMPTS = 3
 
 const processAsins = async (asins: string[]) => {
   for (const asin of asins) {
@@ -142,9 +147,14 @@ const processAsins = async (asins: string[]) => {
         insertGoodreadsData(asin, aggregateGoodreadsData)
       }
     } catch (error) {
-      // Allow a later run to retry this ASIN if the request failed.
-      processedAsins.delete(asin)
-      console.error('Error fetching Goodreads data:', error)
+      // Allow a later run to retry this ASIN, but only up to MAX_ATTEMPTS so a
+      // persistent failure doesn't flood Goodreads on every DOM mutation.
+      const attempts = (failedAttempts.get(asin) ?? 0) + 1
+      failedAttempts.set(asin, attempts)
+      if (attempts < MAX_ATTEMPTS) {
+        processedAsins.delete(asin)
+      }
+      console.error(`Error fetching Goodreads data (attempt ${attempts}/${MAX_ATTEMPTS}):`, error)
     }
   }
 }
@@ -161,7 +171,19 @@ const init = () => {
 
   run()
 
-  const observer = new MutationObserver(() => run())
+  // Coalesce the bursts of mutations Amazon pages emit (lazy images, carousels,
+  // countdown widgets) into a single deferred run so we don't rescan the whole
+  // document on every individual mutation.
+  let scheduled = 0
+  const observer = new MutationObserver(() => {
+    if (scheduled) {
+      return
+    }
+    scheduled = window.setTimeout(() => {
+      scheduled = 0
+      run()
+    }, 500)
+  })
   observer.observe(document.body, { childList: true, subtree: true })
 }
 

--- a/src/plugins/amazon-goodreads-meta/userscript.ts
+++ b/src/plugins/amazon-goodreads-meta/userscript.ts
@@ -2,10 +2,6 @@ const asinRegex = /^[A-Z0-9]{10}$/
 const goodreadsRegex =
   /"aggregateRating":({"@type":"AggregateRating","ratingValue":.*?,"ratingCount":.*?,"reviewCount":.*?})/
 
-// Marks an element as already enriched so repeated runs (e.g. from the
-// MutationObserver) don't insert duplicate badges for the same book.
-const PROCESSED_ATTR = 'data-goodreads-processed'
-
 interface GoodreadsData {
   rating: string
   ratingCount: string
@@ -81,16 +77,15 @@ const insertGoodreadsData = (asin: string, goodreadsData: GoodreadsData) => {
   // badge to the light-DOM host instead of reaching into the shadow DOM, so we
   // don't depend on the shadow structure or its render timing.
   const faceouts = document.querySelectorAll<HTMLElement>('bds-unified-book-faceout')
-  for (const faceout of Array.from(faceouts)) {
+  for (const faceout of faceouts) {
     if (faceout.dataset.csaCItemId !== asin) {
       continue
     }
     const wrapper = faceout.parentElement
-    if (wrapper?.querySelector(`:scope > [${PROCESSED_ATTR}="${asin}"]`)) {
-      return
+    if (!wrapper) {
+      continue
     }
     const badge = buildBadge(goodreadsData)
-    badge.setAttribute(PROCESSED_ATTR, asin)
 
     // Cards in a row (carousels, shelves) have differently-sized text blocks, so
     // a badge placed directly after the faceout ends up at a ragged height. When
@@ -98,7 +93,7 @@ const insertGoodreadsData = (asin: string, goodreadsData: GoodreadsData) => {
     // full-height column and let the badge take the leftover space, so every
     // badge bottom-aligns across the row. Skip this when the wrapper holds more
     // than one faceout (i.e. it's the shared row container, not a single card).
-    const isSingleCardWrapper = wrapper && wrapper.querySelectorAll('bds-unified-book-faceout').length === 1
+    const isSingleCardWrapper = wrapper.querySelectorAll('bds-unified-book-faceout').length === 1
     if (isSingleCardWrapper) {
       wrapper.style.display = 'flex'
       wrapper.style.flexDirection = 'column'
@@ -112,10 +107,8 @@ const insertGoodreadsData = (asin: string, goodreadsData: GoodreadsData) => {
 
   // Single product page: insert after the review summary block.
   const reviewElement = document.getElementById('reviewFeatureGroup')
-  if (reviewElement && !document.querySelector(`[${PROCESSED_ATTR}="${asin}"]`)) {
-    const badge = buildBadge(goodreadsData)
-    badge.setAttribute(PROCESSED_ATTR, asin)
-    reviewElement.parentNode?.insertBefore(badge, reviewElement.nextSibling)
+  if (reviewElement) {
+    reviewElement.parentNode?.insertBefore(buildBadge(goodreadsData), reviewElement.nextSibling)
   }
 }
 

--- a/src/plugins/amazon-goodreads-meta/userscript.ts
+++ b/src/plugins/amazon-goodreads-meta/userscript.ts
@@ -85,11 +85,27 @@ const insertGoodreadsData = (asin: string, goodreadsData: GoodreadsData) => {
     if (faceout.dataset.csaCItemId !== asin) {
       continue
     }
-    if (faceout.parentElement?.querySelector(`:scope > [${PROCESSED_ATTR}="${asin}"]`)) {
+    const wrapper = faceout.parentElement
+    if (wrapper?.querySelector(`:scope > [${PROCESSED_ATTR}="${asin}"]`)) {
       return
     }
     const badge = buildBadge(goodreadsData)
     badge.setAttribute(PROCESSED_ATTR, asin)
+
+    // Cards in a row (carousels, shelves) have differently-sized text blocks, so
+    // a badge placed directly after the faceout ends up at a ragged height. When
+    // the faceout sits in its own per-card wrapper, lay that wrapper out as a
+    // full-height column and let the badge take the leftover space, so every
+    // badge bottom-aligns across the row. Skip this when the wrapper holds more
+    // than one faceout (i.e. it's the shared row container, not a single card).
+    const isSingleCardWrapper = wrapper && wrapper.querySelectorAll('bds-unified-book-faceout').length === 1
+    if (isSingleCardWrapper) {
+      wrapper.style.display = 'flex'
+      wrapper.style.flexDirection = 'column'
+      wrapper.style.height = '100%'
+      badge.style.marginTop = 'auto'
+    }
+
     faceout.insertAdjacentElement('afterend', badge)
     return
   }


### PR DESCRIPTION
## Summary

The **Amazon - Goodreads metadata** userscript had stopped rendering ratings, especially on multi-book listing pages like `/firstreads`. This restores it and makes the insertion more robust across Amazon's various page layouts.

## Root causes fixed

- **Missing `@connect goodreads.com`** — the manifest granted `GM.xmlHttpRequest` but never declared Goodreads as an allowed connect target, so userscript managers blocked every cross-origin lookup and the fetch silently failed.
- **Fragile shadow-DOM insertion** — the badge was inserted into each `<bds-unified-book-faceout>` web component's shadow root, which depended on the component being hydrated and on its internal structure at run time.

## Changes

- Add `connect: 'goodreads.com'` to the manifest.
- Attach the badge to the **light-DOM** faceout host (`insertAdjacentElement('afterend', …)`) instead of reaching into shadow DOM, with a `MutationObserver` to catch books that hydrate after load.
- **Bottom-align** badges across card rows (carousels/shelves) via a flex column on single-card wrappers, so they line up instead of sitting at ragged heights.
- **Debounce** mutation bursts (500 ms) so we don't rescan the whole document on every DOM change.
- **Cap fetch retries** per ASIN at 3 so a transient Goodreads outage can't flood requests on a busy, frequently-mutating page.
- Simplify dedup down to a single `processedAsins` Set as the source of truth (removed the redundant `data-goodreads-processed` DOM guards).

## Verification

- Confirmed live that `https://www.goodreads.com/book/isbn/{ASIN}` resolves the current First Reads ASINs (HTTP 200 → correct book pages) and returns the `aggregateRating` JSON-LD the script parses.
- Manually verified badges render and align correctly on the First Reads page and on a mixed carousel page.

## Known limitation

Dedup is keyed on ASIN, so if the host page removes/re-renders an already-inserted badge (e.g. DOM-recycling carousels), it isn't restored. This is a deliberate simplicity tradeoff; it doesn't affect the common static-grid case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)